### PR TITLE
Remove all any types

### DIFF
--- a/src/Components/FormEmailComponent.tsx
+++ b/src/Components/FormEmailComponent.tsx
@@ -3,6 +3,7 @@ import { Form, Button } from "react-bootstrap";
 import { DebounceInput } from "react-debounce-input";
 import shallow from "zustand/shallow";
 import { sentStore, draftStore, ModalAction } from "./zustand";
+import { v4 as uuidv4 } from "uuid";
 
 interface LocalEmail {
   nameOfSender: string;
@@ -150,9 +151,13 @@ export default function FormemailComponent(props: ModalAction) {
     if (!errors) {
       //Set state to emailDraft and send to draftState in Zustand
       draftStoreArr({
+        id: uuidv4(),
+        profilePicture: "",
         nameOfSender: emailForm.nameOfSender,
         titleOfEmail: emailForm.titleOfEmail,
         bodyMessage: emailForm.bodyMessage,
+        dateOfMessage: "",
+        isAttachment: ""
       });
       handleSetShow();
     } else {
@@ -198,7 +203,15 @@ export default function FormemailComponent(props: ModalAction) {
     */
 
     //Update State
-    sentStateArr(emailForm);
+    sentStateArr({
+      id: uuidv4(),
+      profilePicture: "",
+      nameOfSender: emailForm.nameOfSender,
+      titleOfEmail: emailForm.titleOfEmail,
+      bodyMessage: emailForm.bodyMessage,
+      dateOfMessage: "",
+      isAttachment: ""
+    });
 
     //RESET STATE ON SUBMIT
     setEmailForm({

--- a/src/Components/InboxComponent.tsx
+++ b/src/Components/InboxComponent.tsx
@@ -32,7 +32,7 @@ export const InboxComponent = () => {
     dispatchState(email);
   }
 
-  function deleteHandler(email: EMail): any {
+  function deleteHandler(email: EMail) {
     dispatchDelete(email.id);
     setDeleteMap([email]);
     resetDispatchState();

--- a/src/Components/zustand.tsx
+++ b/src/Components/zustand.tsx
@@ -34,17 +34,17 @@ export interface SearchBarInput {
 
 export interface DeleteMapping {
   deletedState: UpdateState[];
-  setDelete: (email2Del: any) => void;
+  setDelete: (email2Del: [UpdateState]) => void;
 }
 
 export interface SentState {
   sentStateArray: UpdateState[];
-  setStateArray: (arr: any) => void;
+  setStateArray: (arr: UpdateState) => void;
 }
 
 export interface DraftState {
   draftStateArray: UpdateState[];
-  setDraftStateArray: (arr: any) => void;
+  setDraftStateArray: (arr: UpdateState) => void;
 }
 
 //RightSecond Email Dispatch Updating State

--- a/src/Components/zustand.tsx
+++ b/src/Components/zustand.tsx
@@ -29,7 +29,7 @@ export interface EmailActions {
 
 export interface SearchBarInput {
   searchState: string;
-  searchDispatch: any;
+  searchDispatch: (input: string) => void;
 }
 
 export interface DeleteMapping {


### PR DESCRIPTION
Fixes #1 

This PR will remove all instances of type `any` in the codebase and replace them with their correct types.

Some things to note:

In `FormEmailComponent.tsx`, you were only sending part of your `UpdateState` (nameOfSender, titleOfEmail, and bodyMessage) which resulted in inconsistent typing. To remedy this issue, I passed all the email data to the `draftStoreArr` and `sentStateArr` methods.

```js
/* FormEmailComponent.tsx */

draftStoreArr({
  id: uuidv4(),
  profilePicture: "",
  nameOfSender: emailForm.nameOfSender,
  titleOfEmail: emailForm.titleOfEmail,
  bodyMessage: emailForm.bodyMessage,
  dateOfMessage: "",
  isAttachment: ""
});

/* ... */

sentStateArr({
  id: uuidv4(),
  profilePicture: "",
  nameOfSender: emailForm.nameOfSender,
  titleOfEmail: emailForm.titleOfEmail,
  bodyMessage: emailForm.bodyMessage,
  dateOfMessage: "",
  isAttachment: ""
});
```